### PR TITLE
feat(auxmodules): Allow helper modules that enable easy refinement pr…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dump
 
 # SVA intermediate files
 *.pyc.sv
+reset.rseq
 
 # Jasper directory
 jgproject/

--- a/designs/counter/config.json
+++ b/designs/counter/config.json
@@ -1,0 +1,12 @@
+{
+    "jasper" : {
+        "jdir"      : "designs/counter",
+        "script"    : "counter.tcl",
+        "pycfile"   : "counter.pyc.sv",
+        "context"   : "<embedded>::einter"
+    },
+    "spec" : {
+        "pycspec" : "counter",
+        "k"       : 3
+    }
+}

--- a/designs/counter/counter.sv
+++ b/designs/counter/counter.sv
@@ -1,0 +1,43 @@
+
+
+module counter (
+    input clk,
+    input rst,
+    output [7:0] counter
+);
+
+    // Counter that increments by 1
+    logic [7:0] counter_internal;
+
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            counter_internal <= 8'h00;
+        end else begin
+            counter_internal <= counter_internal + 1;
+        end
+    end
+
+    assign counter = counter_internal;
+
+endmodule
+
+
+module parity (
+    input clk,
+    input rst,
+    input [7:0] counter
+);
+
+    // OddEven parity
+    logic parity;
+
+    // toggle parity bit
+    always_ff @(posedge clk or posedge rst) begin
+        if (rst) begin
+            parity <= 1'b0;
+        end else begin
+            parity <= ~parity;
+        end
+    end
+
+endmodule

--- a/designs/counter/counter.tcl
+++ b/designs/counter/counter.tcl
@@ -1,0 +1,85 @@
+set banner "========== New session =========="
+puts $banner
+
+clear -all
+
+# Disable some info messages and warning messages
+# set_message -disable VERI-9033 ; # array automatically black-boxed
+# set_message -disable WNL008 ; # module is undefined. All instances will be black-boxed
+# set_message -disable VERI-1002 ; # Can't disable this error message (net does not have a driver)
+# set_message -disable VERI-1407 ; # attribute target identifier not found in this scope
+set_message -disable VERI-1018 ; # info
+set_message -disable VERI-1328 ; # info
+set_message -disable VERI-2571 ; # info
+# set_message -disable VERI-2571 ; # info: disabling old hierarchical reference handler
+set_message -disable INL011 ; # info: processing file
+# set_message -disable VERI-1482 ; # analyzing verilog file
+set_message -disable VERI-1141 ; # system task is not supported
+set_message -disable VERI-1060 ; # 'initial' construct is ignored
+set_message -disable VERI-1142 ; # system task is ignored for synthesis
+# set_message -disable ISW003 ; # top module name
+# set_message -disable HIER-8002 ; # disabling old hierarchical reference handler
+set_message -disable WNL046 ; # renaming embedded assertions due to name conflicts
+set_message -disable VERI-1995 ; # unique/priority if/case is not full
+                                 # (we check these conditions with the elaborate
+                                 #  option -extract_case_assertions)
+
+set JASPER_FILES {
+    one_trace.sv
+}
+
+set env(DESIGN_HOME) [pwd]
+set err_status [catch {analyze -sv12 +define+JASPER +define+SYNTHESIS +libext+.v+.sv+.vh+.svh+ -f design.lst {*}$JASPER_FILES} err_msg]
+if $err_status {error $err_msg}
+
+elaborate \
+    -top einter \
+    -extract_case_assertions \
+    -no_preconditions \
+
+proc write_reset_seq {file} {
+    puts $file "fvreset 1'b1"
+    puts $file 1
+    puts $file "fvreset 1'b0"
+    puts $file {$}
+    close $file
+}
+
+proc reset_formal {} {
+    write_reset_seq  [open "reset.rseq" w]
+    # reset -expression fvreset
+    reset -sequence "reset.rseq"
+}
+
+
+clock clk
+
+# Constrain primary inputs to only change on @(posedge eph1)
+clock -rate -default clk
+
+reset_formal
+
+# Set default Jasper proof engines (overrides use_nb engine settings)
+#set_engine_mode {Ht Hp B K I N D AG AM Tri}
+set_engine_mode {Ht}
+
+set_max_trace_length 4
+
+# Adds $prefix to each string in $list
+proc map_prefix {prefix list} {
+    set out {}
+    foreach s $list {
+        lappend out "${prefix}${s}"
+    }
+    return $out
+}
+
+# The input signals of a module instance
+proc instance_inputs {inst} {
+    map_prefix "${inst}." [get_design_info -instance $inst -list input -silent]
+}
+
+# The output signals of a module instance
+proc instance_outputs {inst} {
+    map_prefix "${inst}." [get_design_info -instance $inst -list output -silent]
+}

--- a/designs/counter/design.lst
+++ b/designs/counter/design.lst
@@ -1,0 +1,1 @@
+${DESIGN_HOME}/counter.sv

--- a/designs/counter/one_trace.sv
+++ b/designs/counter/one_trace.sv
@@ -1,0 +1,17 @@
+// Parent module with a miter with different inputs
+module einter (
+    input wire clk
+);
+
+    counter a (
+        .clk(clk)
+    );
+
+    default clocking cb @(posedge clk);
+    endclocking // cb
+
+    logic fvreset;
+
+    `include "counter.pyc.sv"
+
+endmodule

--- a/pycaliper/per/__init__.py
+++ b/pycaliper/per/__init__.py
@@ -14,6 +14,8 @@ from .per import (
     PERHole,
     CtrAlignHole,
     SVFunc,
+    AuxPort,
+    AuxModule,
     rose,
     fell,
 )

--- a/pycaliper/per/per.py
+++ b/pycaliper/per/per.py
@@ -142,8 +142,9 @@ class Path:
 class TypedElem:
     """An element in the design hierarchy (Logic, LogicArray, Struct, ...) with a type."""
 
-    def __init__(self):
+    def __init__(self, root: str = None):
         self.name = ""
+        self.root = root
         pass
 
     def instantiate(self, path: Path):
@@ -159,7 +160,7 @@ class TypedElem:
 class Logic(Expr, TypedElem):
     """Class for single bitvectors/signals"""
 
-    def __init__(self, width: int = 1, name: str = "") -> None:
+    def __init__(self, width: int = 1, name: str = "", root: str = None) -> None:
         """
         Args:
             width (int, optional): width of logic signal. Defaults to 1.
@@ -173,6 +174,8 @@ class Logic(Expr, TypedElem):
         self.path: Path = Path([])
         # If member of a logic array, this is the parent array
         self.parent = None
+        # Root
+        self.root = root
 
     def instantiate(self, path: Path, parent: "LogicArray" = None) -> "Logic":
         """Instantiate the logic signal with a path and parent array
@@ -212,6 +215,8 @@ class Logic(Expr, TypedElem):
         Returns:
             str: SVA representation of the signal.
         """
+        if self.root is not None:
+            return f"{self.root}.{self.get_hier_path()}"
         return f"{pref}.{self.get_hier_path()}"
 
     def is_arr_elem(self) -> bool:
@@ -261,6 +266,7 @@ class LogicArray(TypedElem):
         size: int,
         base: int = 0,
         name: str = "",
+        root: str = None,
     ):
         """An array of logic signals
 
@@ -402,17 +408,20 @@ class Inv:
 class Struct(TypedElem):
     """Struct as seen in SV"""
 
-    def __init__(self, name="", **kwargs) -> None:
+    def __init__(self, name="", root: str = None, **kwargs) -> None:
         self.name = name
         self.params = kwargs
         self.path = Path([])
         self._signals: dict[str, TypedElem] = {}
         self._pycinternal__state: list[PER] = []
+        self.root = root
 
     def _typ(self):
         return self.__class__.__name__
 
     def get_sva(self, pref: str = "a") -> str:
+        if self.root is not None:
+            return f"{self.root}.{self.name}"
         return f"{pref}.{self.name}"
 
     def __str__(self) -> str:
@@ -661,13 +670,15 @@ def when(cond: Expr):
 
     return _lambda
 
+
 class SimulationStep:
-    
     def __init__(self) -> None:
         self._pycinternal__assume: list[Expr] = []
         self._pycinternal__assert: list[Expr] = []
+
     def _assume(self, expr: Expr):
         self._pycinternal__assume.append(expr)
+
     def _assert(self, expr: Expr):
         self._pycinternal__assert.append(expr)
 
@@ -678,9 +689,14 @@ def unroll(b: int):
             for i in range(b):
                 self._pycinternal__simstep = SimulationStep()
                 func(self, i)
-                self._pycinternal__simsteps.append(copy.deepcopy(self._pycinternal__simstep))
+                self._pycinternal__simsteps.append(
+                    copy.deepcopy(self._pycinternal__simstep)
+                )
+
         return wrapper
+
     return unroll_decorator
+
 
 class Module:
     """Module class for specifications related to a SV HW module"""
@@ -714,11 +730,13 @@ class Module:
         self._pycinternal__output_invs: list[Inv] = []
         # Non-invariant properties
         self._pycinternal__simsteps: list[SimulationStep] = []
-        self._pycinternal__simstep : SimulationStep = SimulationStep()
+        self._pycinternal__simstep: SimulationStep = SimulationStep()
         # PER holes
         self._perholes: list[PERHole] = []
         # CtrAlign holes
         self._caholes: list[CtrAlignHole] = []
+
+        self._auxmodules: dict[str, AuxModule] = {}
 
     # Invariant functions to be overloaded by descendant specification classes
     def input(self) -> None:
@@ -856,8 +874,10 @@ class Module:
         if self._context == Context.UNROLL:
             self._pycinternal__simstep._assert(expr)
         else:
-            logger.warning("pycassert can only be used in the unroll context, skipping.")
-        
+            logger.warning(
+                "pycassert can only be used in the unroll context, skipping."
+            )
+
     def pycassume(self, expr: Expr) -> None:
         """Add an assumption to the current context.
 
@@ -867,8 +887,9 @@ class Module:
         if self._context == Context.UNROLL:
             self._pycinternal__simstep._assume(expr)
         else:
-            logger.warning("pycassume can only be used in the unroll context, skipping.")
-
+            logger.warning(
+                "pycassume can only be used in the unroll context, skipping."
+            )
 
     def instantiate(self, path: Path = Path([])) -> "Module":
         """Instantiate the current Module.
@@ -888,6 +909,7 @@ class Module:
         groupattrs = {}
         funcattrs = {}
         submoduleattrs = {}
+        auxmoduleattrs = {}
         for attr in dir(self):
             obj = getattr(self, attr)
             if (
@@ -907,6 +929,11 @@ class Module:
                 if obj.name == "":
                     obj.name = attr
                 funcattrs[obj.name] = obj
+            elif isinstance(obj, AuxModule):
+                # Current module must be top level
+                if obj.name == "":
+                    obj.name = attr
+                auxmoduleattrs[obj.name] = obj.instantiate(path.add_level(obj.name))
             elif isinstance(obj, Module):
                 if obj.name == "":
                     obj.name = attr
@@ -915,6 +942,7 @@ class Module:
         self._groups = groupattrs
         self._functions = funcattrs
         self._submodules = submoduleattrs
+        self._auxmodules = auxmoduleattrs
         # Call the specification generator methods.
         self._context = Context.INPUT
         self.input()
@@ -955,7 +983,6 @@ class Module:
             for i in self._perholes:
                 s += f"\t{i.per} ({i.ctx})\n"
         return s
-
 
     def get_repr(self, reprs):
         # Find all submodules and structs that need to be defined
@@ -1053,6 +1080,52 @@ class {self.__class__.__name__}(Module):
 
     def pprint(self):
         print(self.sprint())
+
+
+class AuxPort(Logic):
+    def __init__(self, width: int = 1, name: str = "", root: str = None) -> None:
+        super().__init__(width, name, root)
+
+
+class AuxModule(Module):
+    def __init__(self, portmapping: dict[str, TypedElem], name="", **kwargs) -> None:
+        super().__init__(name, **kwargs)
+        self._pycinternal__ports = {}
+        self.portmapping = portmapping
+
+    def instantiate(self, root: Path = Path([])) -> None:
+        self.path = Path([])
+        for attr in dir(self):
+            obj = getattr(self, attr)
+            if isinstance(obj, AuxPort):
+                self._pycinternal__ports[obj.name] = obj.instantiate(
+                    self.path.add_level(obj.name)
+                )
+                obj.root = root.get_hier_path()
+            elif isinstance(obj, TypedElem):
+                obj.root = root.get_hier_path()
+                obj.instantiate(self.path.add_level(obj.name))
+        # Check that all ports are mapped
+        for k in self.portmapping:
+            if k not in self._pycinternal__ports:
+                logger.error(f"Port {k} not found in {self.__class__.__name__}")
+                sys.exit(1)
+        return self
+
+    def get_instance_str(self, bindm: str):
+        portbindings = []
+        for k, v in self.portmapping.items():
+            portbindings.append(f".{k}({bindm}.{v})")
+        portbindings = ",\n\t".join(portbindings)
+
+        aux_mod_decl = f"""
+// Module {self.get_hier_path()}
+{self.__class__.__name__} {self.name} (
+        // Bindings
+        {portbindings}
+);
+"""
+        return aux_mod_decl
 
 
 # SVA-specific functions

--- a/pycaliper/pycmanager.py
+++ b/pycaliper/pycmanager.py
@@ -30,14 +30,15 @@ class PYCTask(Enum):
     PERSYNTH = 5
     FULLSYNTH = 6
 
+
 class PYCArgs(BaseModel):
-    path : str
-    mock : bool = False
-    params : str = ""
-    sdir : str = ""
-    port : int = 8080
-    onetrace : bool = False
-    bmc : bool = False
+    path: str
+    mock: bool = False
+    params: str = ""
+    sdir: str = ""
+    port: int = 8080
+    onetrace: bool = False
+    bmc: bool = False
 
 
 class PYConfig(BaseModel):
@@ -64,6 +65,8 @@ class PYConfig(BaseModel):
     pycspec: str = ""
     # bound to use for the k-inductive proof
     k: int = 1
+    # Use only one trace for verification
+    onetrace: bool = False
 
     # Directory of pre-provided traces
     tdir: str = ""
@@ -81,9 +84,14 @@ class PYCManager:
         self.pycspec: str = pyconfig.pycspec
         # Previous VCD traces directory
 
+        self.pyconfig = pyconfig
         self.sdir = pyconfig.sdir
 
-        self.wdir = tempfile.TemporaryDirectory(prefix="pyc_wdir_").name
+        # Create a temporary directory for the run, grab the name, and clean it up
+        wdir = tempfile.TemporaryDirectory(prefix="pyc_wdir_")
+        self.wdir = wdir.name
+        wdir.cleanup()
+
         logger.info(f"Working directory: {self.wdir}")
         self.tracedir = f"{self.wdir}/traces"
         self.specdir = f"{self.wdir}/specs"
@@ -141,6 +149,13 @@ class PYCManager:
             # Copy wdir to sdir
             os.system(f"cp -r {self.wdir}/. {self.sdir}/")
 
+    def close(self):
+        # Close the socket
+        self.save()
+        if not self.pyconfig.mock:
+            jgc.close_tcp()
+        logger.info("PyCaliper run completed, socket closed.")
+
 
 CONFIG_SCHEMA = {
     "type": "object",
@@ -192,7 +207,7 @@ CONFIG_SCHEMA = {
 
 def create_module(specc, args):
     """Dynamically import the spec module and create an instance of it."""
-    specmod : str = specc["pycspec"]
+    specmod: str = specc["pycspec"]
     params = specc.get("params", {})
 
     parsed_conf = {}
@@ -202,9 +217,9 @@ def create_module(specc, args):
 
     params.update(parsed_conf)
 
-    if '/' in specmod:
+    if "/" in specmod:
         # Split the module name into the module name and the parent package
-        module_path, module_name = specmod.rsplit('/', 1)
+        module_path, module_name = specmod.rsplit("/", 1)
 
         # Check if the path exists
         if not os.path.isdir(module_path):
@@ -212,14 +227,18 @@ def create_module(specc, args):
             exit(1)
         # Add the module path to sys.path
         sys.path.append(module_path)
-    
+
         try:
             # Import the module using importlib
             module = importlib.import_module(module_name)
-            logger.debug(f"Successfully imported module: {module_name} from {module_path}")
+            logger.debug(
+                f"Successfully imported module: {module_name} from {module_path}"
+            )
             return getattr(module, module_name)(**params)
         except ImportError as e:
-            logger.error(f"Error importing module {module_name} from {module_path}: {e}")
+            logger.error(
+                f"Error importing module {module_name} from {module_path}: {e}"
+            )
             return None
         finally:
             # Clean up: remove the path from sys.path to avoid potential side effects
@@ -259,6 +278,7 @@ def get_pyconfig(config, args: PYCArgs) -> PYConfig:
         # Spec config
         pycspec=specc["pycspec"],
         k=specc["k"],
+        onetrace=args.onetrace,
         # Tracing configuration
         # Location where traces are provided
         tdir=tracec.get("tdir", ""),

--- a/pycaliper/verif/jgverifier.py
+++ b/pycaliper/verif/jgverifier.py
@@ -12,7 +12,7 @@ from ..jginterface.jgoracle import (
     disable_assm,
     set_assm_induction_1t,
     set_assm_induction_2t,
-    set_assm_bmc
+    set_assm_bmc,
 )
 
 from .invverifier import InvVerifier
@@ -38,7 +38,9 @@ class JGVerifier1Trace(InvVerifier):
         """
 
         self.svagen = svagen.SVAGen(module)
-        self.svagen.create_pyc_specfile(filename=self.psc.pycfile, k=self.psc.k)
+        self.svagen.create_pyc_specfile(
+            filename=self.psc.pycfile, k=self.psc.k, onetrace=True
+        )
         self.candidates = self.svagen.holes
 
         loadscript(self.psc.script)
@@ -80,6 +82,7 @@ class JGVerifier2Trace(InvVerifier):
         logger.info(f"Two trace verification result: {res_str}")
         return res
 
+
 class JGVerifier1TraceBMC(InvVerifier):
     """One trace property verifier with BMC"""
 
@@ -106,7 +109,11 @@ class JGVerifier1TraceBMC(InvVerifier):
         set_assm_bmc(self.psc.context, self.svagen.property_context)
 
         results = [is_pass(r) for r in prove_out_bmc(self.psc.context, self.psc.k)]
-        results_str = '\n\t'.join(
-            [f"Step {i}: SAFE" if res else f"Step {i}: UNSAFE" for (i, res) in enumerate(results)])
+        results_str = "\n\t".join(
+            [
+                f"Step {i}: SAFE" if res else f"Step {i}: UNSAFE"
+                for (i, res) in enumerate(results)
+            ]
+        )
         logger.info(f"One trace verification result:\n\t{results_str}")
         return results

--- a/specs/counter.py
+++ b/specs/counter.py
@@ -1,0 +1,39 @@
+# auxmod.py
+
+from pycaliper.per import *
+from pycaliper.per.per import TypedElem
+
+
+class parity(AuxModule):
+    def __init__(self, portmapping: dict[str, TypedElem], name="", **kwargs) -> None:
+        super().__init__(portmapping, name, **kwargs)
+        self.clk = AuxPort(1, "clk")
+        self.rst = AuxPort(1, "rst")
+        self.counter = AuxPort(8, "counter")
+        self.parity = Logic(1, "parity")
+
+
+class counter(Module):
+    def __init__(self, name="", **kwargs) -> None:
+        super().__init__(name, **kwargs)
+        self.clk = Logic(1, "clk")
+        self.rst = Logic(1, "rst")
+        self.counter = Logic(8, "counter")
+
+        self.parity = parity(
+            {
+                "clk": self.clk,
+                "rst": self.rst,
+                "counter": self.counter,
+            },
+            name="monitor",
+        )
+
+    def input(self) -> None:
+        pass
+
+    def state(self) -> None:
+        self.inv(self.counter(0) == self.parity.parity)
+
+    def output(self) -> None:
+        pass


### PR DESCRIPTION
…oofs:

- `AuxModule`: an external Module that is hooked up at the top level: - allows addition of auxilliary (extra) signals - specifications can refer to these signals
- example: `designs/counter` and `specs/counter.py`

fix(onetrace): One trace verification needs to only dump properties with one instance

TODO: clean-up the PyConfig and TaskMgr classes, they can most probably be combined, making interfaces simpler